### PR TITLE
Improve file parsing and add reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-1
+# Rubric Web App Design
+
+This repository contains a high-level plan for a web application that assists teachers in creating lesson plans, assessments, and rubrics using the Gemini API.
+
+## Workflow Overview
+
+1. **Pre-Step: Teaching Philosophy and Direction**
+   - Teachers upload one or more files (PDF, HWP, Docs, TXT, etc.) along with notes describing the overall teaching philosophy.
+   - The server stores the files, extracts any readable text (PDF and DOCX supported), and summarizes the combined notes. This summary is used as context in later stages.
+
+2. **Lesson Design Chat**
+   - Teachers chat with the system using the Gemini API to discuss lesson structure and assessments.
+
+3. **Lesson Plan Generation**
+   - Once planning is complete, Gemini generates a lesson plan document. Teachers can save it as **HWP** or **TXT**.
+
+4. **Assessment Creation**
+   - After the lesson plan, teachers continue the conversation to craft assessments.
+   - Assessments are also downloadable as **HWP** or **TXT** files.
+
+5. **Rubric Design**
+   - Gemini helps create a rubric for the assessments.
+   - Rubrics can be saved as **HWP** or **TXT** files.
+
+## Optional Steps
+
+Teachers may skip any of the steps above. For example, a teacher can jump directly to rubric design, in which case the system asks for enough information to generate the rubric.
+
+
+## Running the App
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the development server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. The API will be available at `http://127.0.0.1:8000`.
+
+There is also a `/reset` endpoint to clear any stored conversation and background summary.
+
+These endpoints are minimal placeholders that save uploaded files and generate
+simple text outputs. Integrate the Gemini API to replace the stub logic.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a high-level plan for a web application that assists te
 
 1. **Pre-Step: Teaching Philosophy and Direction**
    - Teachers upload one or more files (PDF, HWP, Docs, TXT, etc.) along with notes describing the overall teaching philosophy.
-   - The server stores the files, extracts any readable text (PDF and DOCX supported), and summarizes the combined notes. This summary is used as context in later stages.
+   - The server stores the files, extracts any readable text (PDF, DOCX and basic HWP support), and summarizes the combined notes. This summary is used as context in later stages.
 
 2. **Lesson Design Chat**
    - Teachers chat with the system using the Gemini API to discuss lesson structure and assessments.
@@ -40,8 +40,9 @@ Teachers may skip any of the steps above. For example, a teacher can jump direct
 3. The API will be available at `http://127.0.0.1:8000`.
 
 The server stores conversation history and the background summary in **Firebase**.
-The default configuration in `app/main.py` uses a sample Firebase project. If
-you wish to use your own, edit the `FIREBASE_CONFIG` dictionary.
+The default configuration in `app/main.py` uses a sample Firebase project.
+You can override these settings by providing a JSON string in the
+`FIREBASE_CONFIG_JSON` environment variable.
 
 There is also a `/reset` endpoint to clear any stored conversation and background summary.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Teachers may skip any of the steps above. For example, a teacher can jump direct
    ```
 3. The API will be available at `http://127.0.0.1:8000`.
 
+The server stores conversation history and the background summary in **Firebase**.
+The default configuration in `app/main.py` uses a sample Firebase project. If
+you wish to use your own, edit the `FIREBASE_CONFIG` dictionary.
+
 There is also a `/reset` endpoint to clear any stored conversation and background summary.
 
 These endpoints are minimal placeholders that save uploaded files and generate

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,109 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import FileResponse
+from pathlib import Path
+from typing import List
+
+from pdfminer.high_level import extract_text as extract_pdf_text
+from docx import Document
+
+
+def extract_text_from_file(path: Path) -> str:
+    """Extract text from PDF, DOCX, or TXT files."""
+    if path.suffix.lower() == ".pdf":
+        return extract_pdf_text(str(path))
+    if path.suffix.lower() in {".docx", ".doc"}:
+        try:
+            doc = Document(str(path))
+            return "\n".join(p.text for p in doc.paragraphs)
+        except Exception:
+            return ""
+    if path.suffix.lower() in {".txt"}:
+        return path.read_text(errors="ignore")
+    # Unsupported file types are ignored
+    return ""
+
+def summarize_text(text: str, word_limit: int = 50) -> str:
+    """Return the first `word_limit` words from the provided text."""
+    words = text.split()
+    return " ".join(words[:word_limit])
+
+app = FastAPI(title="Rubric Web App")
+
+UPLOAD_DIR = Path("uploads")
+UPLOAD_DIR.mkdir(exist_ok=True)
+
+# In-memory storage
+conversation: List[str] = []
+background_summary: str = ""
+
+
+@app.post("/reset")
+async def reset_state():
+    """Clear conversation history and background summary."""
+    conversation.clear()
+    global background_summary
+    background_summary = ""
+    return {"status": "reset"}
+
+@app.post("/upload-philosophy")
+async def upload_philosophy(
+    files: List[UploadFile] = File(...), notes: str = Form("")
+):
+    """Upload teaching philosophy materials and optional notes."""
+    uploaded = []
+    combined_text = notes
+    for file in files:
+        filepath = UPLOAD_DIR / file.filename
+        with filepath.open("wb") as f:
+            content = await file.read()
+            f.write(content)
+        uploaded.append(file.filename)
+        combined_text += "\n" + extract_text_from_file(filepath)
+
+    global background_summary
+    background_summary = summarize_text(combined_text)
+    return {"uploaded": uploaded, "summary": background_summary}
+
+@app.post("/chat")
+async def chat(message: str = Form(...)):
+    """Chat about lesson design."""
+    conversation.append(message)
+    # Placeholder response instead of Gemini API
+    if background_summary:
+        response = (
+            f"Response placeholder using background: {background_summary[:30]}..."
+        )
+    else:
+        response = "Response placeholder"
+    return {"message": message, "response": response}
+
+@app.post("/generate-plan")
+async def generate_plan(filetype: str = Form("txt")):
+    """Generate a lesson plan from conversation."""
+    content = "Lesson plan placeholder\n"
+    if background_summary:
+        content += f"Background summary:\n{background_summary}\n\n"
+    content += "\n".join(conversation)
+    filename = f"lesson_plan.{filetype}"
+    Path(filename).write_text(content)
+    return FileResponse(filename, media_type="text/plain", filename=filename)
+
+@app.post("/generate-assessment")
+async def generate_assessment(filetype: str = Form("txt")):
+    """Generate an assessment."""
+    content = "Assessment placeholder\n"
+    if background_summary:
+        content += f"Background summary:\n{background_summary}\n"
+    filename = f"assessment.{filetype}"
+    Path(filename).write_text(content)
+    return FileResponse(filename, media_type="text/plain", filename=filename)
+
+@app.post("/generate-rubric")
+async def generate_rubric(filetype: str = Form("txt")):
+    """Generate a rubric for the assessment."""
+    content = "Rubric placeholder\n"
+    if background_summary:
+        content += f"Background summary:\n{background_summary}\n"
+    filename = f"rubric.{filetype}"
+    Path(filename).write_text(content)
+    return FileResponse(filename, media_type="text/plain", filename=filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pdfminer.six
+python-docx

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pdfminer.six
 python-docx
+pyrebase4==4.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pdfminer.six
 python-docx
 pyrebase4==4.7.1
+olefile


### PR DESCRIPTION
## Summary
- extract text from PDF/DOCX uploads to build a background summary
- add `/reset` endpoint to clear stored data
- document new behavior and endpoint in README
- include pdfminer.six and python-docx in requirements

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d24e1f6288323a0943ef6e809e4ee